### PR TITLE
Small updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,5 +8,6 @@ Description: KPIC2 is an effective platform for LC-MS based metabolomics using p
 License: GPL (>= 2)
 Encoding: UTF-8
 LazyData: true
-Imports: Rcpp, RcppArmadillo, mzR, parallel, shiny, plotly, data.table, GA, IRanges, dbscan, Ckmeans.1d.dp
+Imports: Rcpp, RcppArmadillo, mzR, parallel, shiny, plotly, data.table, GA, IRanges, dbscan, Ckmeans.1d.dp,
+  jsonlite, randomForest, ropls, Matrix
 LinkingTo: Rcpp, RcppArmadillo

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,7 +3,9 @@ exportPattern("LoadData","getPIC","getPIC.kmeans","getPIP","PICset","PICset.kmea
               "PICresolve","PICfit","PICset.split","PICset.resolve","PICset.getPeaks","PICgroup",
               "PICset.fit","PICalign","viewAlign","readPICs","groupCombine","analyst.RF","analyst.OPLS",
               "viewPseudospecturm","getDataMatrix","fillPeaks.EIBPC","WMPD")
-import('GA', 'data.table', 'dbscan', 'mzR', 'parallel', 'plotly')
+import('GA', 'data.table', 'dbscan', 'mzR', 'parallel', 'plotly', 'jsonlite', 'Ckmeans.1d.dp',
+       'ropls', 'shiny', 'Matrix', 'randomForest')
 importFrom(Rcpp, evalCpp)
 importFrom("stats", "approx", "fft", "median", "mvfft", "quantile", "sd")
+importFrom("IRanges", "whichAsIRanges")
 useDynLib(KPIC)

--- a/R/Analyst.R
+++ b/R/Analyst.R
@@ -1,7 +1,4 @@
 analyst.RF <- function(labels, data){
-  library(shiny)
-  library(plotly)
-  library(randomForest)
   
   labels <- as.factor(labels)
   data <- as.matrix(data)
@@ -127,9 +124,6 @@ analyst.RF <- function(labels, data){
 }
 
 analyst.OPLS <- function(labels, data){
-  library(shiny)
-  library(plotly)
-  library(ropls)
   labels <- as.vector(labels)
   data <- as.matrix(data)
 

--- a/R/Fillpeaks.R
+++ b/R/Fillpeaks.R
@@ -1,5 +1,4 @@
 getDataMatrix <- function(groups, std='maxo'){
-  library(data.table)
   group.info <- as.data.table(groups$group.info)
   if (!'cluster'%in%colnames(group.info)){
     group.info[,cluster:=1:nrow(group.info)]
@@ -74,7 +73,6 @@ fillPeaks.EIBPC <- function(groups, extand_mz=20, extand_rt=5, min_snr=3, std='m
 }
 
 .EIBPC <- function(raw, mzrange, rtrange){
-  library(data.table)
   scans <- findInterval(rtrange, raw$times)
   inds <- findInterval(scans, raw$scans)
   inds <- inds[1]:inds[2]

--- a/R/IO.R
+++ b/R/IO.R
@@ -5,7 +5,7 @@ LoadData <- function(filename)
   {
     msobj <- openMSfile(filename,backend="netCDF")
   }else{
-    msobj <- openMSfile(filename,backend="Ramp")
+    msobj <- openMSfile(filename)
   }
 
   peakInfo <- peaks(msobj)

--- a/R/IO.R
+++ b/R/IO.R
@@ -1,6 +1,5 @@
 LoadData <- function(filename)
 {
-  library(mzR)
   splitname <- strsplit(filename,"\\.")[[1]]
   if(tolower(splitname[length(splitname)]) == "cdf")
   {
@@ -32,7 +31,6 @@ LoadData <- function(filename)
 }
 
 readPICs <- function(files){
-  library(rjson)
   filepattern <- c("[j][s][o][n]")
   filepattern <- paste(paste("\\.", filepattern, "$", sep = ""), collapse = "|")
   info <- file.info(files)

--- a/R/PICalign.R
+++ b/R/PICalign.R
@@ -1,5 +1,4 @@
 PICset.align <- function(groups, method='fftcc', move='direct', span=1.5){
-  library(data.table)
   peakmat <- as.matrix(groups$peakmat)
   picset <- groups$picset
   group.info <- groups$group.info

--- a/R/PICgroup.R
+++ b/R/PICgroup.R
@@ -1,6 +1,4 @@
 PICset.group <- function(picset, tolerance=c(0.01,10),weight=c(0.8,0.2), method='score', frac=0.5){
-  library(dbscan)
-  library(data.table)
 
   minSample = max(1, frac*length(picset))
   peakmat <- lapply(picset, function(pics){
@@ -103,7 +101,6 @@ PICset.group <- function(picset, tolerance=c(0.01,10),weight=c(0.8,0.2), method=
 }
 
 groupCombine <- function(groups,min_corr=0.9,type='tailed',window=10){
-  library(data.table)
 
   peakmat <- groups$peakmat
   picset <- groups$picset
@@ -140,7 +137,6 @@ groupCombine <- function(groups,min_corr=0.9,type='tailed',window=10){
 }
 
 getPseudospecturm <- function(groups, clu.id){
-  library(data.table)
   peakmat <- groups$peakmat
   setkey(peakmat, group)
   group.info <- groups$group.info

--- a/R/PICset.R
+++ b/R/PICset.R
@@ -24,7 +24,6 @@ rtequal <- function(rt0,pics){
 }
 
 PICset <- function(files, level, mztol=0.1, gap=3, width=5, min_snr=4, equal=TRUE, export=FALSE, par=TRUE, ...){
-  library(parallel)
   path <- readfiles(files)
 
   if (par){
@@ -52,7 +51,6 @@ PICset <- function(files, level, mztol=0.1, gap=3, width=5, min_snr=4, equal=TRU
 }
 
 PICset.kmeans <- function(files, level, mztol=0.1, gap=3, width=c(5,60), min_snr=4, alpha=0.3, equal=TRUE, export=FALSE, par=TRUE, ...){
-  library(parallel)
   cl <- makeCluster(getOption("cl.cores", detectCores(logical = FALSE)))
   path <- readfiles(files)
 
@@ -80,7 +78,6 @@ PICset.kmeans <- function(files, level, mztol=0.1, gap=3, width=c(5,60), min_snr
 }
 
 PICset.split <- function(picset, par=FALSE) {
-  library(parallel)
   if (!par){
     for (i in 1:length(picset)){
       picset[[i]] <- PICsplit(picset[[i]])
@@ -95,7 +92,6 @@ PICset.split <- function(picset, par=FALSE) {
 }
 
 PICset.resolve <- function(picset, pval=0.01, par=FALSE) {
-  library(parallel)
   if (!par){
     for (i in 1:length(picset)){
       picset[[i]] <- PICresolve(picset[[i]], pval)
@@ -110,7 +106,6 @@ PICset.resolve <- function(picset, pval=0.01, par=FALSE) {
 }
 
 PICset.fit <- function(picset, iter=50, par=FALSE) {
-  library(parallel)
   if (!par){
     for (i in 1:length(picset)){
       picset[[i]] <- PICfit(picset[[i]], iter)

--- a/R/Peak.R
+++ b/R/Peak.R
@@ -56,8 +56,6 @@ integration <- function(x,yf){
 }
 
 WMPD <- function(pic, min_snr, level, pval, iter){
-  library(Matrix)
-  library(IRanges)
   vec <- pic[,2]
   rts <- pic[,1]
   mzs <- pic[,3]
@@ -122,7 +120,6 @@ WhittakerSmooth <- function(y,lambda){
 }
 
 plot.resolve <- function(pic, res){
-  library(plotly)
   rts <- pic[,1]
   raw.vec <- pic[,2]
   fit.pics <- do.call(rbind, res$fitpics)

--- a/R/Visual.R
+++ b/R/Visual.R
@@ -1,5 +1,4 @@
 getTICs <- function(files, method='BPC'){
-  library(mzR)
   path <- readfiles(files)
   tics <- lapply(path,function(filename){
     splitname <- strsplit(filename,"\\.")[[1]]
@@ -29,8 +28,6 @@ getTICs <- function(files, method='BPC'){
 }
 
 viewTICs <- function(tics){
-  library(shiny)
-  library(plotly)
 
   ui <- fluidPage(
     titlePanel("TIC Viewer"),
@@ -65,7 +62,6 @@ viewTICs <- function(tics){
 }
 
 getMS <- function(filename){
-  library(mzR)
 
   splitname <- strsplit(filename,"\\.")[[1]]
   if(tolower(splitname[length(splitname)]) == "cdf")
@@ -102,8 +98,6 @@ stem <- function(x,y,pch=5,linecol=1,col='blue',cex.lab=1.2,cex.axis=1.3,font=2,
 }
 
 viewMS <- function(MS){
-  library(shiny)
-  library(plotly)
 
   ui <- fluidPage(
     titlePanel("MS Viewer"),
@@ -136,8 +130,6 @@ viewMS <- function(MS){
 }
 
 viewPICs <- function(pics){
-  library(shiny)
-  library(plotly)
 
   ui <- fluidPage(
     titlePanel("PIC Viewer"),
@@ -185,8 +177,6 @@ viewPICs <- function(pics){
 }
 
 viewGroups <- function(groups){
-  library(shiny)
-  library(plotly)
 
   ui <- fluidPage(
     titlePanel("groups Viewer"),
@@ -229,9 +219,6 @@ viewGroups <- function(groups){
 }
 
 viewAlign <- function(groups_raw, groups_align){
-  library(shiny)
-  library(plotly)
-  library(data.table)
 
   peakmat_raw <- as.data.table(groups_raw$peakmat)
   setkey(peakmat_raw, group)
@@ -328,8 +315,6 @@ viewAlign <- function(groups_raw, groups_align){
 }
 
 viewPseudospecturm <- function(groups){
-  library(shiny)
-  library(plotly)
 
   ui <- fluidPage(
     titlePanel("Pseudospecturm Viewer"),

--- a/R/getPIC.R
+++ b/R/getPIC.R
@@ -52,7 +52,6 @@ getPIC <- function(raw, level, mztol=0.1, gap=3, width=5, min_snr=4, export='FAL
 
   output <- list(path=path, scantime=scantime, pics=pics, peaks=peaks)
   if (export){
-    library(rjson)
     exportJSON <- toJSON(output)
     splitname <- strsplit(path,"\\.")[[1]][1]
     outpath <- paste(splitname,'json',sep='.')
@@ -63,8 +62,6 @@ getPIC <- function(raw, level, mztol=0.1, gap=3, width=5, min_snr=4, export='FAL
 }
 
 getPIC.kmeans <- function(raw, level, mztol=0.1, gap=3, width=c(5,60), alpha=0.3, min_snr=4, export='FALSE', ...){
-  library(Ckmeans.1d.dp)
-  library(data.table)
 
   orders <- order(raw$mzs)
   mzs <- raw$mzs[orders]
@@ -133,7 +130,6 @@ getPIC.kmeans <- function(raw, level, mztol=0.1, gap=3, width=c(5,60), alpha=0.3
 
   output <- list(path=path, scantime=scantime, pics=pics, peaks=peaks)
   if (export){
-    library(rjson)
     exportJSON <- toJSON(output)
     splitname <- strsplit(filename,"\\.")[[1]][1]
     outpath <- paste(splitname,'json',sep='.')
@@ -280,8 +276,6 @@ getPeaks <- function(pics){
 }
 
 PICresolve <- function(pics, pval=0.01){
-  library(IRanges)
-  library(stats)
 
   pics1 <- list()
   peaks1 <- list()
@@ -414,7 +408,6 @@ PICresolve <- function(pics, pval=0.01){
 }
 
 PICfit <- function(pics, iter=50){
-  library(GA)
   peaks1 <- list()
   pics1 <- list()
   for (s in 1:length(pics$pics)) {


### PR DESCRIPTION
Hello,

This PR involves several small updates to `KPIC2`:

- The `DESCRIPTION` and `NAMESPACE` files now list all R package dependencies.
- `rjson` package was changed to `jsonlite` (former not always available on CRAN)
- The default backend for `mzR` file loading with `openMSfile` is not set to the older `Ramp` backend anymore.
- All `library()` calls were removed, as this is generally not recommended to have for R packages.
